### PR TITLE
add defaut input source config support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,8 @@ In your vim/neovim, run command:
 
 ## Options
 
+- `imselect.defaultInput` default input source use in normal mode, default to `com.apple.keylayout.US`.
+
 - `imselect.cursorHighlight` highlight cursor color, default to `65535,65535,0`.
 
   The syntax for color is `red,green,blue` where each value is a number between 0 and 65535.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
     "configuration": {
       "type": "object",
       "properties": {
+        "imselect.defaultInput": {
+          "type": "string",
+          "default": "com.apple.keylayout.US",
+          "description": "default input source use in normal mode"
+        },
         "imselect.cursorHighlight": {
           "type": "string",
           "default": "65535,65535,0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ const pty = require('node-pty')
 
 const method_cache: Map<number, string> = new Map()
 
-let defaultInput = 'com.apple.keylayout.US'
 let currentMethod: string
 let currentLang: string
 let defaultColor: Color
@@ -14,6 +13,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   let { subscriptions, logger } = context
   let config = workspace.getConfiguration('imselect')
   let highlights = config.get<string>('cursorHighlight', '65535,65535,0').split(/,\s*/)
+  let defaultInput = config.get<string>('defaultInput', 'com.apple.keylayout.US')
 
   async function selectDefault(): Promise<void> {
     if (currentLang == 'en') return


### PR DESCRIPTION
it make sense to support config the default input source. since i like to use `ABC` source instead of `US`